### PR TITLE
Update TsIRTCummulative.txt

### DIFF
--- a/examples/scorers/IRTCummulative/TsIRTCummulative.txt
+++ b/examples/scorers/IRTCummulative/TsIRTCummulative.txt
@@ -69,5 +69,7 @@ d:Sc/gvalue/PulseTimeMean     = 0.9 us
 d:Sc/gvalue/PulseTimeFWHM     = 1.8 us 
 sv:Sc/gvalue/ReportMoleculesNamed = 10 "OH^0" "e_aq^-1" "H3O^1" "H2O2^0" "H^0" "H_2^0" "OH^-1" "O2^-1" "HO2^0" "O2^0"
 s:Sc/gvalue/SensitiveVolumeName  = "target"
+b:Sc/gvalue/ForceLowTimeCutTo1ps = "True"
+b:Sc/gvalue/EnableHighTimeScavengers = "True"
 
 #######################


### PR DESCRIPTION
Fix issue reported in 
https://github.com/topas-nbio/TOPAS-nBio/issues/86 that changing of the background reaction (Type VI)  scavenging rates and concentrations  does not have any effect on the outcome in the phase space file of the chemical species.

The changes were made based on the suggestions made in the forum discussion https://github.com/topas-nbio/TOPAS-nBio/discussions/7