### PR TITLE
Fix for issue 94 in TsScoreWithIRTCummulative

### DIFF
--- a/processes/TsIRT.cc
+++ b/processes/TsIRT.cc
@@ -63,6 +63,7 @@ void TsIRT::Sampling(){
 
 		G4int t = (*it).first; 
 
+		// Make sure that the molecule time is not 0.0 when fStepTimes are modified by Scoring options to avoid wrong initialization of Gvalues, which can lead to wrong results
 		G4int tBin = fUtils->FindBin(aMol.time, fStepTimes);
 		if ( -1 < tBin ) {
 			for ( int tbin = tBin; tbin < (int)fStepTimes.size(); tbin++ ) {

--- a/scorers/TsScoreWithIRTCummulative.cc
+++ b/scorers/TsScoreWithIRTCummulative.cc
@@ -74,6 +74,11 @@ fPm(pM), fEnergyDepositPerEvent(0), fEnergyDepositPerEventEverywhere(0), fName(s
     fLowLimitTo1ps = false;
     if ( fPm->ParameterExists(GetFullParmName("ForceLowTimeCutTo1ps")) )
         fLowLimitTo1ps = fPm->GetBooleanParameter(GetFullParmName("ForceLowTimeCutTo1ps"));
+
+    fTimeLower = 1.0 * ps;
+    if ( fPm->ParameterExists(GetFullParmName("TimeLower")) )
+        fTimeLower = fPm->GetDoubleParameter(GetFullParmName("TimeLower"),"Time");
+
     
     if ( fTimeDistribution == "gaussian" ) {
         fTimeDistributionType = 1;
@@ -266,12 +271,14 @@ void TsScoreWithIRTCummulative::UserHookForPreTimeStepAction() {
             if ( fTestIsInside ) {
                 const G4String& volumeName = (*it_begin)->GetVolume()->GetName();
                 if ( volumeName.contains(fSensitiveVolume) ) {
-                    G4double time = fShiftTime;
+                    //make sure that no molecule is created before the starting time of IRT as defined by the TimeLower parameter
+                    G4double time = std::max(fShiftTime,fTimeLower);
                     fIRT->AddMolecule(*it_begin, time, 0, G4ThreeVector());
                 }
             }
             else {
-                fIRT->AddMolecule(*it_begin, fShiftTime, 0, G4ThreeVector());
+                G4double time = std::max(fShiftTime,fTimeLower);
+                fIRT->AddMolecule(*it_begin, time, 0, G4ThreeVector());
             }
         }
         

--- a/scorers/TsScoreWithIRTCummulative.hh
+++ b/scorers/TsScoreWithIRTCummulative.hh
@@ -84,6 +84,8 @@ private:
 	G4int fOldEvent;
 	G4double fShiftTime;
 	G4double fMinShiftTime;
+	G4double fTimeLower;
+
 	
 	G4double* fTimeValues;
 	G4double* fTimeWeights;


### PR DESCRIPTION
Fixes: https://github.com/topas-nbio/TOPAS-nBio/issues/94

In simulations where the time of the initially created molecules is lower than the starting time for the IRT processes an initial check can fail:
aMol.time <  fStepTimes[0]
in the fUtils->FindBin method.
This can happen in the case of the 'cumulative/interpulse' scorer, when the "TimeLower" parameter is set.
In such a situation the the check in TsIRT.cc fails, which makes sure that the GValues are initialized:


		G4int tBin = fUtils->FindBin(aMol.time, fStepTimes);

		if ( -1 < tBin ) {

			for ( int tbin = tBin; tbin < (int)fStepTimes.size(); tbin++ ) {

				if ( fTheGvalue.find(aMol.id) == fTheGvalue.end() ) {

					fTheGvalue[aMol.id][tbin] = 1;

				} else {

					fTheGvalue[aMol.id][tbin]++; 

				}

			}

Therefore the accounting does not work properly and can lead to negative values.
The solution is to add an additional check in TsScoreWithIRTCummulative to make sure that the molecule times is > that the startint time of the IRT.